### PR TITLE
Refactor Component & Widget System; Alpha Blending

### DIFF
--- a/ext/architect/render.c
+++ b/ext/architect/render.c
@@ -39,6 +39,7 @@ VALUE create_renderer(VALUE _self, VALUE window)
 	Data_Get_Struct(window, SDL_Window, win);
 
 	SDL_Renderer *rend = SDL_CreateRenderer(win, -1, SDL_RENDERER_ACCELERATED);
+	SDL_SetRenderDrawBlendMode(rend, SDL_BLENDMODE_BLEND);
 
 	VALUE object = Data_Wrap_Struct(rb_cObject, 0, free_ptr, rend);
 

--- a/src/component/box.rb
+++ b/src/component/box.rb
@@ -36,11 +36,6 @@ class Box < Component
     end
   end
 
-  def render(renderer)
-    # Draw children
-    children.each { |c| c.render(renderer) }
-  end
-
   def child_x(comp)
     index = child_index(comp)
     return dynamic_x + comp.x if direction == :column || index.nil?

--- a/src/component/component.rb
+++ b/src/component/component.rb
@@ -1,9 +1,15 @@
+require 'securerandom'
+
 class Component
   extend ReactiveAccessor
   include UnwrapReactive
   include UnwrapComputed
 
-  reactive_accessor :x, :y, :children, :parent, :widget, :position
+  attr_reader :id
+  attr_writer :parent
+  attr_accessor :widget
+
+  reactive_accessor :x, :y, :position
 
   # Creates an empty component.
   # This will do nothing in itself and will not render.
@@ -16,15 +22,20 @@ class Component
   # @option options [Symbol] :position
   #   Valid options are `:absolute` or `:dynamic`.
   def initialize(options)
+    @id = SecureRandom.hex.to_sym
+
     set(
       {
         x: 0, y: 0,
-        children: [],
-        position: :dynamic,
-        parent: nil, widget: nil
+        position: :dynamic, widget: nil
       },
       force: true
     )
+
+    @parent = nil
+    @widget = nil
+    @children = []
+
     set(options)
   end
 
@@ -64,19 +75,39 @@ class Component
     instance_variable_get(:"@#{name}")
   end
 
-  def render(_renderer)
-    raise 'Render method must be defined!'
-  end
+  def render(_renderer); end
 
   # Adds the component to the root tree.
   def add_to_root
-    widget.add_component(self)
+    widget.add_component(@id, self)
   end
 
   # Adds a child to the `children` array
   def add_child(component)
-    component.parent = self
-    component.widget = @widget
-    children << component
+    widget.add_component(component.id, component)
+    component.parent = @id
+    component.widget = widget
+    @children << component.id
+  end
+
+  # Removes a child from the tree
+  def remove_child(component)
+    component.parent = nil
+    component.remove
+    @children.delete(component.id)
+  end
+
+  # Removes itself from the tree
+  def remove
+    parent.remove_child(self) unless @parent.nil?
+    widget.remove_component(@id)
+  end
+
+  def parent
+    widget.components[@parent]
+  end
+
+  def children
+    @children.map { |c| widget.components[c] }
   end
 end

--- a/src/component/component.rb
+++ b/src/component/component.rb
@@ -70,7 +70,7 @@ class Component
 
   # Adds the component to the root tree.
   def add_to_root
-    $WIDGETS[$WIDGET_BUFFER].add_component(self)
+    widget.add_component(self)
   end
 
   # Adds a child to the `children` array

--- a/src/component/rectangle.rb
+++ b/src/component/rectangle.rb
@@ -38,9 +38,6 @@ class Rectangle < Component
     else
       Architect.render_rounded_rectangle(renderer, pos_x, pos_y, dynamic_width, dynamic_height, rounding)
     end
-
-    # Draw children
-    children.each { |c| c.render(renderer) }
   end
 
   def add_event(event, only_hover: true, &block)

--- a/src/component/root.rb
+++ b/src/component/root.rb
@@ -12,8 +12,4 @@ class Root < Component
 
     super({ x: 0, y: 0 })
   end
-
-  def render(renderer)
-    children.each { |c| c.render(renderer) }
-  end
 end

--- a/src/main.rb
+++ b/src/main.rb
@@ -30,7 +30,7 @@ end
 threads = {}
 
 # @param [Widget] widget
-$WIDGETS.each do |name, widget|
+$WIDGETS.each_value do |name, widget|
   threads[name] = Thread.new do
     win_opts = widget.options.filter { |k, _| %i[title x y width height type background_color].include? k }
 

--- a/src/main.rb
+++ b/src/main.rb
@@ -47,7 +47,7 @@ $WIDGETS.each_value do |name, widget|
       window.render do
         # Render the widget components
         # @param [Component] component
-        widget.components.each do |component|
+        widget.components_array.each do |component|
           component.render(renderer)
         end
       end

--- a/src/widget.rb
+++ b/src/widget.rb
@@ -7,12 +7,18 @@ require_relative 'reactivity/watch'
 $WIDGETS = {}
 
 class Widget
-  attr_reader :options, :components, :events
+  attr_reader :options, :components, :components_array, :events
   attr_accessor :has_root
 
   def initialize(options, components)
     @options = options
+
+    # @type [Hash]
     @components = components
+
+    # @type [Array<Component>]
+    @components_array = []
+    cache_components
 
     # @type [Array<Proc>]
     @events = []
@@ -20,8 +26,21 @@ class Widget
     @has_root = false
   end
 
-  def add_component(component)
-    @components << component
+  # Adds a component to the widget
+  def add_component(id, component)
+    @components[id] = component
+    @components_array << component
+  end
+
+  # Removes a component from the widget
+  def remove_component(id)
+    @components[id]
+    @components_array.delete_if { |c| c.id == id }
+  end
+
+  # Turns the current component hash into an array
+  def cache_components
+    @components_array = @components.values
   end
 
   # Runs before every render tick
@@ -70,7 +89,7 @@ end
 #   - `:dock` will create a docked window.
 def make_widget(options)
   caller = caller_locations(1, 1).first.absolute_path
-  $WIDGETS[caller][1] = Widget.new(options, [])
+  $WIDGETS[caller][1] = Widget.new(options, {})
 end
 
 # Create a component.

--- a/src/window.rb
+++ b/src/window.rb
@@ -54,8 +54,6 @@ class Window
     yield
 
     Architect.render_present @renderer
-
-    # Architect.render_delay(1000 / 60)
   end
 
   def exit


### PR DESCRIPTION
- We now use the caller of `make` to add components to widgets.
- We now use an ID based system for resolving components, instead of storing child and parent references.
- We allow alpha blending when setting the draw color.